### PR TITLE
Removed dependency on deprecated Nette\Object

### DIFF
--- a/src/Controls/NotTranslatableRadioList.php
+++ b/src/Controls/NotTranslatableRadioList.php
@@ -62,14 +62,10 @@ class NotTranslatableRadioList extends Nette\Forms\Controls\RadioList
 	 * @return void
 	 */
 	public static function register($control_name = 'addNotTranslatableRadioList') {
-		Nette\Object::extensionMethod(
-			'Nette\Forms\Container::' . $control_name,
-			function ($form, $name, $label = NULL, array $items = NULL) {
-				$control = new self($label, $items);
+		Nette\Forms\Container::extensionMethod($control_name, function ($form, $name, $label = NULL, array $items = NULL) {
+			$control = new self($label, $items);
 
-				return $form[$name] = $control;
-			}
-		);
+			return $form[$name] = $control;
+		});
 	}
-
 }

--- a/src/Controls/NotTranslatableSelectBox.php
+++ b/src/Controls/NotTranslatableSelectBox.php
@@ -73,18 +73,15 @@ class NotTranslatableSelectBox extends Nette\Forms\Controls\SelectBox
 	 * @return void
 	 */
 	public static function register($control_name = 'addNotTranslatableSelect') {
-		Nette\Object::extensionMethod(
-			'Nette\Forms\Container::' . $control_name,
-			function ($form, $name, $label = NULL, array $items = NULL, $size = NULL) {
-				$control = new self($label, $items);
+		Nette\Forms\Container::extensionMethod($control_name, function ($form, $name, $label = NULL, array $items = NULL, $size = NULL) {
+			$control = new self($label, $items);
 
-				if ($size > 1) {
-					$control->setAttribute('size', (int) $size);
-				}
-
-				return $form[$name] = $control;
+			if ($size > 1) {
+				$control->setAttribute('size', (int) $size);
 			}
-		);
+
+			return $form[$name] = $control;
+		});
 	}
 
 }

--- a/src/Controls/TextInputCustomLabel.php
+++ b/src/Controls/TextInputCustomLabel.php
@@ -19,14 +19,11 @@ class TextInputCustomLabel extends Nette\Forms\Controls\TextInput
 	 * @return void
 	 */
 	public static function register($control_name = 'addTextCustomLabel') {
-		Nette\Object::extensionMethod(
-			'Nette\Forms\Container::' . $control_name,
-			function ($form, $name, $label = NULL, array $items = NULL) {
-				$control = new self($label, $items);
+		Nette\Forms\Container::extensionMethod($control_name, function ($form, $name, $label = NULL, array $items = NULL) {
+			$control = new self($label, $items);
 
-				return $form[$name] = $control;
-			}
-		);
+			return $form[$name] = $control;
+		});
 	}
 
 


### PR DESCRIPTION
- added calling of method "Nette\Forms\Container::extensionMethod" instead of "Nette\Object::extensionMethod"